### PR TITLE
Update rubidium checker

### DIFF
--- a/src/main/java/com/anthonyhilyard/iceberg/renderer/CheckedBufferSource.java
+++ b/src/main/java/com/anthonyhilyard/iceberg/renderer/CheckedBufferSource.java
@@ -1,10 +1,5 @@
 package com.anthonyhilyard.iceberg.renderer;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-
-import com.anthonyhilyard.iceberg.Loader;
-
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -16,7 +11,7 @@ public class CheckedBufferSource implements MultiBufferSource
 	protected boolean hasRendered = false;
 	protected final MultiBufferSource bufferSource;
 
-	private static Boolean useSodiumVersion = null;
+	protected static final boolean useSodiumVersion = ModList.get().isLoaded("rubidium");
 
 	protected CheckedBufferSource(MultiBufferSource bufferSource)
 	{
@@ -25,30 +20,9 @@ public class CheckedBufferSource implements MultiBufferSource
 
 	public static CheckedBufferSource create(MultiBufferSource bufferSource)
 	{
-		if (useSodiumVersion == null)
+		if (useSodiumVersion)
 		{
-			try
-			{
-				// Check if Rubidium 0.7.1+ is installed using Forge API.
-				useSodiumVersion = ModList.get().isLoaded("rubidium") && ModList.get().getModContainerById("rubidium").get().getModInfo().getVersion().compareTo(new DefaultArtifactVersion("0.7.1")) >= 0;
-			}
-			catch (Exception e)
-			{
-				Loader.LOGGER.error(ExceptionUtils.getStackTrace(e));
-			}
-		}
-
-		if (useSodiumVersion != null && useSodiumVersion)
-		{
-			// Instantiate the Rubidium implementation using reflection.
-			try
-			{
-				return (CheckedBufferSource) Class.forName("com.anthonyhilyard.iceberg.renderer.CheckedBufferSourceSodium").getDeclaredConstructor(MultiBufferSource.class).newInstance(bufferSource);
-			}
-			catch (Exception e)
-			{
-				Loader.LOGGER.error(ExceptionUtils.getStackTrace(e));
-			}
+			return new CheckedBufferSourceSodium(bufferSource);
 		}
 
 		return new CheckedBufferSource(bufferSource);

--- a/src/main/java/com/anthonyhilyard/iceberg/renderer/VertexCollector.java
+++ b/src/main/java/com/anthonyhilyard/iceberg/renderer/VertexCollector.java
@@ -1,18 +1,16 @@
 package com.anthonyhilyard.iceberg.renderer;
 
+import static com.anthonyhilyard.iceberg.renderer.CheckedBufferSource.useSodiumVersion;
+
 import java.util.Set;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.joml.Vector3f;
 
-import com.anthonyhilyard.iceberg.Loader;
 import com.google.common.collect.Sets;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraftforge.fml.ModList;
 
 public class VertexCollector implements MultiBufferSource
 {
@@ -21,8 +19,6 @@ public class VertexCollector implements MultiBufferSource
 	protected int currentAlpha = 255;
 	protected int defaultAlpha = 255;
 
-	private static Boolean useSodiumVersion = null;
-
 	protected VertexCollector()
 	{
 		super();
@@ -30,30 +26,9 @@ public class VertexCollector implements MultiBufferSource
 
 	public static VertexCollector create()
 	{
-		if (useSodiumVersion == null)
+		if (useSodiumVersion)
 		{
-			try
-			{
-				// Check if Rubidium 0.7.1+ is installed using Forge API.
-				useSodiumVersion = ModList.get().isLoaded("rubidium") && ModList.get().getModContainerById("rubidium").get().getModInfo().getVersion().compareTo(new DefaultArtifactVersion("0.7.1")) >= 0;
-			}
-			catch (Exception e)
-			{
-				Loader.LOGGER.error(ExceptionUtils.getStackTrace(e));
-			}
-		}
-
-		if (useSodiumVersion != null && useSodiumVersion)
-		{
-			// Instantiate the Sodium implementation using reflection.
-			try
-			{
-				return (VertexCollector) Class.forName("com.anthonyhilyard.iceberg.renderer.VertexCollectorSodium").getDeclaredConstructor().newInstance();
-			}
-			catch (Exception e)
-			{
-				Loader.LOGGER.error(ExceptionUtils.getStackTrace(e));
-			}
+			return new VertexCollectorSodium();
 		}
 		return new VertexCollector();
 	}


### PR DESCRIPTION
Minecraft will crash anyway, whether you are checking the rubidium version or not, but if you are not checking its version, it is less likely to crash.